### PR TITLE
15 move the manifestjson from chromefirefox branch to main branch

### DIFF
--- a/.github/workflows/create_zip.yml
+++ b/.github/workflows/create_zip.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - chrome
-      - firefox
-    paths-ignore:
-      - '*.zip'
 
 jobs:
   build:
@@ -30,7 +26,7 @@ jobs:
         path: ${{ matrix.browser }}
 
     - name: Copy scripts and icons from main branch to ${{ matrix.browser }} branch
-      run: cp -r temp/scripts ${{ matrix.browser }} && cp -r temp/icons ${{ matrix.browser }}
+      run: cp -r temp/scripts ${{ matrix.browser }} && cp -r temp/icons ${{ matrix.browser }} && cp temp/manifest.json ${{ matrix.browser }}
 
     - name: Create zip file with ${{ matrix.browser }} branch contents
       run: cd ${{ matrix.browser }} && zip -r ${{ matrix.browser }}.zip *

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,26 @@
+{
+    "manifest_version": 3,
+    "name": "ChatGPT Citations",
+    "version": "1",
+    "description": "Generates BibLaTeX citations from chat conversations with OpenAI's ChatGPT.",
+    "icons": {
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png",
+      "48": "icons/icon-48.png",
+      "128": "icons/icon-128.png"
+    },
+    "content_scripts": [
+      {
+        "matches": [
+          "https://chat.openai.com/",
+          "https://chat.openai.com/*"
+        ],
+       "js": [
+          "scripts/utils.js",
+          "scripts/api.js",
+          "scripts/ui.js",
+          "scripts/main.js"
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
Now there is only one  `manifest.json`  which can be found in the main branch. Having two  `manifest.json`  for each browser was indeed unnecessary as they were "identical". Besides that, I have updated the GitHub action to copy the `manifest.json`  from the main branch when creating a zip for x browser.